### PR TITLE
Update getItemFor() in Handler.js

### DIFF
--- a/src/registry/Handler.js
+++ b/src/registry/Handler.js
@@ -33,7 +33,7 @@ export default class HandlerRegistry extends Base {
 		for (let item of this[ITEMS]) {
 			const {handler, key} = item;
 
-			if (typeof key === 'function' && key(...args)) {
+			if ((typeof key === 'function' && key(...args)) || (args.includes(key))) {
 				return handler;
 			}
 		}


### PR DESCRIPTION
Update Handler.js to account for items registered without using a decorator.
EDIT: 
sorry for not explaining well. I am not sure what `typeof key === 'function' && key(...args)` does exactly. 
My proposed edits allowed me to return the handler (the react ref) given its MimeType. Before I did my edits locally, I was unable to retrieve the Notification Types given their MimeType using `Handler.getItemFor()`. I think if someone explains `typeof key === 'function' && key(...args)`, I would have a better idea about the whole thing. @jsg2021 @aligon 
Thanks!